### PR TITLE
Fix path to ui.css for header rendering

### DIFF
--- a/website/views/termbase-edit/navigator.ejs
+++ b/website/views/termbase-edit/navigator.ejs
@@ -166,7 +166,7 @@
 			</script>
 		<%}%>
 
-		<link type="text/css" rel="stylesheet" href="../../../furniture/ui.css" />
+		<link type="text/css" rel="stylesheet" href="../../furniture/ui.css" />
 	</head>
 	<body class="x-narrow x-editorShown">
 		<%-include("../header.ejs", {user: user, termbaseID: termbaseID, termbaseConfigs: termbaseConfigs, sectionID: "edit", rootPath: "../../", L: L})%>


### PR DESCRIPTION
The header style did not render correctly on my instance (using a base URL with a subdirectory) without this change. After the change, the header renders correctly, like e.g. in the config view. The same href value is used there, see https://github.com/gaois/terminologue/blob/e6dba8485fc9602a9fe76398d3712bade8ead755/website/views/termbase-config/home.ejs#L31