### PR TITLE
Fix home page layout broken on small screens

### DIFF
--- a/website/furniture/public.css
+++ b/website/furniture/public.css
@@ -164,11 +164,14 @@ body.sitehome .invelope.top > div.clear {clear: both;}
 [dir="rtl"] div.rightie {float: right; width: 50%; box-sizing: border-box; border-right: 1px solid #03A491; padding: 20px 40px 20px 0px; position: relative; right: -1px;}
 @media (max-width: 800px){
   body.sitehome .invelope.top {margin-top: 50px;}
-  div.leftie {float: none; width: auto; box-sizing: border-box; padding: 0px 0px 0px 0px; border-right: 0px}
-  div.rightie {float: none; width: auto; box-sizing: border-box; padding: 40px 0px 0px 0px; border-left: 0px; left: 0px; margin-top: 40px;}
+  [dir="ltr"] div.leftie,
+  [dir="rtl"] div.leftie {float: none; width: auto; box-sizing: border-box; padding: 0px 0px 0px 0px; border-right: 0px}
+  [dir="ltr"] div.rightie,
+  [dir="rtl"] div rightie {float: none; width: auto; box-sizing: border-box; padding: 40px 0px 0px 0px; border-left: 0px; left: 0px; margin-top: 40px;}
 }
 
 div.welcome {font-size: 1.1rem; line-height: 1.5em; color: #666666; min-height: 500px;}
+@media (max-width: 800px){ div.welcome {min-height: unset;} }
 div.welcome > div.intro {color: #333333;}
 div.welcome > div.point { margin: 20px 0px;}
 div.welcome > div.point > div.title {}
@@ -188,6 +191,7 @@ div.welcome > div.point > div.subblurb > div.add {margin-top: 10px; padding-top:
 
 html[dir="ltr"] div.usertop {background-image: url(user.png); background-position: left center; background-repeat: no-repeat; padding-left: 80px; min-height: 60px; margin-bottom: 20px;}
 html[dir="rtl"] div.usertop {background-image: url(user.png); background-position: right center; background-repeat: no-repeat; padding-right: 80px; min-height: 60px; margin-bottom: 20px;}
+div.usertop { overflow-x: auto }
 div.usertop a {text-decoration: none; color: #047063;}
 div.usertop a:hover {color: #059080; }
 div.usertop > div.title {font-size: 1.5rem; padding-top: 10px;}


### PR DESCRIPTION
The home page layout is broken on narrow screens. This is because while the `leftie` and `rightie` classes have screen size rules that try to make them stacked vertically on narrow screens, these rules are not taking effect as they don't have enough specificity.

This PR fixes that, as well as making the welcome element not demand a minimum height on narrow screens, and making the user email get its own scrollbar if necessary instead of overflowing the whole page.

| Before | After |
|-|-|
| <img width="490" height="853" alt="螢幕截圖_20260623_184044" src="https://github.com/user-attachments/assets/bfa65f42-60dd-459c-ab4a-692e51601931" /> | <img width="487" height="832" alt="螢幕截圖_20260623_184844" src="https://github.com/user-attachments/assets/06f1f945-d50a-41bb-b0cd-646c087054ec" /> |