### PR TITLE
Fix unusable textboxes in narrow screens

### DIFF
--- a/website/libs/fy/fy.css
+++ b/website/libs/fy/fy.css
@@ -212,3 +212,19 @@ button.metadataOpener {
 .fy_body.domains .fy_nolineabove button.metadataOpener {
   display: none !important;
 }
+
+@media(max-width: 500px) {
+  .fy_label {
+    width: 100% !important;
+  }
+  .fy_textbox {
+    position: relative !important;
+    inset-inline: 0 !important;
+    display: block !important;
+  }
+  .fy_textbox > select {
+    /* Like fy_label */
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+  }
+}


### PR DESCRIPTION
(This is the best glossary editor I've ever seen, thank you; sorry for suddenly popping up 3 PRs)

On small screens, many text inputs in Terminologue become unusable as they are on the same line as their labels, and their labels assume there is enough space to use a fixed 200-something px width, resulting in the label taking up a bunch of space for nothing while the input is squished to the side.

While IMO ideally this would be fixed with a refactoring away from inline styles towards styles that are easier to override in a media rule, here I've simply tried to apply a few more rules (with liberal use of `!important` to override inline styles where necessary) so that on narrow screens these inputs are displayed on a second line.

| Before | After |
|-|-|
| <img width="335" height="500" alt="螢幕截圖_20260623_190012" src="https://github.com/user-attachments/assets/89abdbe9-e4f4-4119-b087-2aa1e85fa207" /> | <img width="335" height="500" alt="螢幕截圖_20260623_190053" src="https://github.com/user-attachments/assets/11a649ac-3608-4b1e-89f3-4563b98ef0d7" /> |